### PR TITLE
build: update HAProxy from 3.3.10 to 3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM build-base AS build
 RUN apk add \
       ca-certificates
 WORKDIR /tmp/haproxy
-ADD --checksum=sha256:6aa919a13f3a575416ef0ae45da0ecb35f1a8d004641dd684fe9b53e646891f2 https://www.haproxy.org/download/3.3/src/haproxy-3.3.10.tar.gz /tmp/haproxy.tar.gz
+ADD --checksum=sha256:9298f565c2a9ba8a4e7f89c54be2c5d3fd960b5b304eb5515e15d29d2c15d4f7 https://www.haproxy.org/download/3.4/src/haproxy-3.4.0.tar.gz /tmp/haproxy.tar.gz
 RUN tar -xzvf /tmp/haproxy.tar.gz --strip-components=1
 COPY --from=build-openssl /opt/openssl ./openssl
 COPY --from=build-pcre /opt/pcre ./pcre

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 Available on Docker Hub as [`docker.io/ricardbejarano/haproxy`](https://hub.docker.com/r/ricardbejarano/haproxy):
 
-- [`3.3.10`, `latest` *(Dockerfile)*](Dockerfile)
+- [`3.4.0`, `latest` *(Dockerfile)*](Dockerfile)
 
 ### RedHat Quay
 
 Available on RedHat Quay as [`quay.io/ricardbejarano/haproxy`](https://quay.io/repository/ricardbejarano/haproxy):
 
-- [`3.3.10`, `latest` *(Dockerfile)*](Dockerfile)
+- [`3.4.0`, `latest` *(Dockerfile)*](Dockerfile)
 
 
 ## Configuration


### PR DESCRIPTION
Bumps HAProxy from 3.3.10 to 3.4.0.

Release notes: https://www.haproxy.org/