### PR TITLE
bump openssl 3.6.2 → 3.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apk add \
 
 FROM build-base AS build-openssl
 WORKDIR /tmp/openssl
-ARG OPENSSL_VERSION="3.6.2"
-ADD --checksum=sha256:aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz /tmp/openssl.tar.gz
+ARG OPENSSL_VERSION="3.6.3"
+ADD --checksum=sha256:243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1 https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz /tmp/openssl.tar.gz
 RUN tar -xzvf /tmp/openssl.tar.gz --strip-components=1 \
     && ./config --prefix=/opt/openssl --no-shared \
     && make -j"$(nproc)" \


### PR DESCRIPTION
Bumps OpenSSL from 3.6.2 to 3.6.3 (latest of the 3.6.x line).

Checksum verified against the official `openssl-3.6.3.tar.gz.sha256` published with the [OpenSSL 3.6.3 release](https://github.com/openssl/openssl/releases/tag/openssl-3.6.3):

```
243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1  openssl-3.6.3.tar.gz
```

PCRE2 (10.47), zlib (1.3.2) and HAProxy (3.4.0) are already at their latest releases, so no other changes are needed. The image tag is unaffected, so `README.md` needs no update.